### PR TITLE
fix: signed-in feed unseen filter

### DIFF
--- a/app/schemas/com.omersusin.pitube.data.local.AppDatabase/29.json
+++ b/app/schemas/com.omersusin.pitube.data.local.AppDatabase/29.json
@@ -1,0 +1,1247 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 29,
+    "identityHash": "b1646c4f2c474e4fe8f63c26dcf01895",
+    "entities": [
+      {
+        "tableName": "videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `channelName` TEXT NOT NULL, `channelId` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `duration` INTEGER NOT NULL, `viewCount` INTEGER NOT NULL, `uploadDate` TEXT NOT NULL, `description` TEXT NOT NULL, `channelThumbnailUrl` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `savedAt` INTEGER NOT NULL, `isMusic` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewCount",
+            "columnName": "viewCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadDate",
+            "columnName": "uploadDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelThumbnailUrl",
+            "columnName": "channelThumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMusic",
+            "columnName": "isMusic",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `isPrivate` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `videoCount` INTEGER NOT NULL, `isMusic` INTEGER NOT NULL, `isUserCreated` INTEGER NOT NULL, `syncId` TEXT, `profileId` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "isPrivate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoCount",
+            "columnName": "videoCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMusic",
+            "columnName": "isMusic",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUserCreated",
+            "columnName": "isUserCreated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "syncId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_syncId",
+            "unique": false,
+            "columnNames": [
+              "syncId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_syncId` ON `${TABLE_NAME}` (`syncId`)"
+          },
+          {
+            "name": "index_playlists_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_video_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `videoId` TEXT NOT NULL, `position` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `videoId`), FOREIGN KEY(`playlistId`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`videoId`) REFERENCES `videos`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "videoId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_video_cross_ref_videoId",
+            "unique": false,
+            "columnNames": [
+              "videoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_video_cross_ref_videoId` ON `${TABLE_NAME}` (`videoId`)"
+          },
+          {
+            "name": "index_playlist_video_cross_ref_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_video_cross_ref_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "videos",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "videoId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `videoId` TEXT NOT NULL, `title` TEXT NOT NULL, `channelName` TEXT NOT NULL, `thumbnailUrl` TEXT, `timestamp` INTEGER NOT NULL, `isRead` INTEGER NOT NULL, `type` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "music_home_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sectionId` TEXT NOT NULL, `title` TEXT NOT NULL, `subtitle` TEXT, `tracksJson` TEXT NOT NULL, `orderBy` INTEGER NOT NULL, PRIMARY KEY(`sectionId`))",
+        "fields": [
+          {
+            "fieldPath": "sectionId",
+            "columnName": "sectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tracksJson",
+            "columnName": "tracksJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderBy",
+            "columnName": "orderBy",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sectionId"
+          ]
+        }
+      },
+      {
+        "tableName": "music_home_chips_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `browseId` TEXT, `params` TEXT, `deselectBrowseId` TEXT, `deselectParams` TEXT, `orderBy` INTEGER NOT NULL, PRIMARY KEY(`title`))",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browseId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "params",
+            "columnName": "params",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectBrowseId",
+            "columnName": "deselectBrowseId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectParams",
+            "columnName": "deselectParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderBy",
+            "columnName": "orderBy",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "title"
+          ]
+        }
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `title` TEXT NOT NULL, `uploader` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT NOT NULL, `thumbnailPath` TEXT, `createdAt` INTEGER NOT NULL, `sponsorBlockSegmentsJson` TEXT, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploader",
+            "columnName": "uploader",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailPath",
+            "columnName": "thumbnailPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sponsorBlockSegmentsJson",
+            "columnName": "sponsorBlockSegmentsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "download_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `videoId` TEXT NOT NULL, `fileType` TEXT NOT NULL, `fileName` TEXT NOT NULL, `filePath` TEXT NOT NULL, `url` TEXT NOT NULL, `format` TEXT NOT NULL, `quality` TEXT NOT NULL, `mimeType` TEXT NOT NULL, `downloadedBytes` INTEGER NOT NULL, `totalBytes` INTEGER NOT NULL, `status` TEXT NOT NULL, FOREIGN KEY(`videoId`) REFERENCES `downloads`(`videoId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "fileType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBytes",
+            "columnName": "totalBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_items_videoId",
+            "unique": false,
+            "columnNames": [
+              "videoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_items_videoId` ON `${TABLE_NAME}` (`videoId`)"
+          },
+          {
+            "name": "index_download_items_filePath",
+            "unique": true,
+            "columnNames": [
+              "filePath"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_download_items_filePath` ON `${TABLE_NAME}` (`filePath`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "downloads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "videoId"
+            ],
+            "referencedColumns": [
+              "videoId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "watch_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `position` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `channelName` TEXT NOT NULL, `channelId` TEXT NOT NULL, `isMusic` INTEGER NOT NULL, `isShort` INTEGER NOT NULL, `isLocal` INTEGER NOT NULL, `profileId` TEXT NOT NULL, PRIMARY KEY(`videoId`, `profileId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMusic",
+            "columnName": "isMusic",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShort",
+            "columnName": "isShort",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId",
+            "profileId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_watch_history_videoId",
+            "unique": false,
+            "columnNames": [
+              "videoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_videoId` ON `${TABLE_NAME}` (`videoId`)"
+          },
+          {
+            "name": "index_watch_history_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_watch_history_isMusic",
+            "unique": false,
+            "columnNames": [
+              "isMusic"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_isMusic` ON `${TABLE_NAME}` (`isMusic`)"
+          },
+          {
+            "name": "index_watch_history_isShort",
+            "unique": false,
+            "columnNames": [
+              "isShort"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_isShort` ON `${TABLE_NAME}` (`isShort`)"
+          },
+          {
+            "name": "index_watch_history_isLocal",
+            "unique": false,
+            "columnNames": [
+              "isLocal"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_isLocal` ON `${TABLE_NAME}` (`isLocal`)"
+          }
+        ]
+      },
+      {
+        "tableName": "home_feed_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `profileId` TEXT NOT NULL, `bucket` TEXT NOT NULL, `videoId` TEXT NOT NULL, `title` TEXT NOT NULL, `channelName` TEXT NOT NULL, `channelId` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `duration` INTEGER NOT NULL, `viewCount` INTEGER NOT NULL, `likeCount` INTEGER NOT NULL, `uploadDate` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `description` TEXT NOT NULL, `channelThumbnailUrl` TEXT NOT NULL, `tagsJson` TEXT NOT NULL, `isMusic` INTEGER NOT NULL, `isLive` INTEGER NOT NULL, `isShort` INTEGER NOT NULL, `isUpcoming` INTEGER NOT NULL, `commentCountText` TEXT NOT NULL, `source` TEXT NOT NULL, `relatedSeedId` TEXT, `cachedAt` INTEGER NOT NULL, `expiresAt` INTEGER NOT NULL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bucket",
+            "columnName": "bucket",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewCount",
+            "columnName": "viewCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "likeCount",
+            "columnName": "likeCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadDate",
+            "columnName": "uploadDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelThumbnailUrl",
+            "columnName": "channelThumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMusic",
+            "columnName": "isMusic",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLive",
+            "columnName": "isLive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShort",
+            "columnName": "isShort",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUpcoming",
+            "columnName": "isUpcoming",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentCountText",
+            "columnName": "commentCountText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedSeedId",
+            "columnName": "relatedSeedId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_home_feed_cache_bucket_expiresAt",
+            "unique": false,
+            "columnNames": [
+              "bucket",
+              "expiresAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_home_feed_cache_bucket_expiresAt` ON `${TABLE_NAME}` (`bucket`, `expiresAt`)"
+          },
+          {
+            "name": "index_home_feed_cache_bucket_source",
+            "unique": false,
+            "columnNames": [
+              "bucket",
+              "source"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_home_feed_cache_bucket_source` ON `${TABLE_NAME}` (`bucket`, `source`)"
+          },
+          {
+            "name": "index_home_feed_cache_relatedSeedId",
+            "unique": false,
+            "columnNames": [
+              "relatedSeedId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_home_feed_cache_relatedSeedId` ON `${TABLE_NAME}` (`relatedSeedId`)"
+          },
+          {
+            "name": "index_home_feed_cache_videoId",
+            "unique": false,
+            "columnNames": [
+              "videoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_home_feed_cache_videoId` ON `${TABLE_NAME}` (`videoId`)"
+          },
+          {
+            "name": "index_home_feed_cache_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_home_feed_cache_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscription_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `channelIds` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelIds",
+            "columnName": "channelIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        }
+      },
+      {
+        "tableName": "recognition_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackId` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT, `coverArtUrl` TEXT, `coverArtHqUrl` TEXT, `genre` TEXT, `releaseDate` TEXT, `label` TEXT, `shazamUrl` TEXT, `appleMusicUrl` TEXT, `spotifyUrl` TEXT, `isrc` TEXT, `youtubeVideoId` TEXT, `recognizedAt` INTEGER NOT NULL, `liked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "trackId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtUrl",
+            "columnName": "coverArtUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtHqUrl",
+            "columnName": "coverArtHqUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "releaseDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shazamUrl",
+            "columnName": "shazamUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "appleMusicUrl",
+            "columnName": "appleMusicUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "spotifyUrl",
+            "columnName": "spotifyUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeVideoId",
+            "columnName": "youtubeVideoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recognizedAt",
+            "columnName": "recognizedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "liked",
+            "columnName": "liked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recognition_history_trackId",
+            "unique": false,
+            "columnNames": [
+              "trackId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_trackId` ON `${TABLE_NAME}` (`trackId`)"
+          },
+          {
+            "name": "index_recognition_history_recognizedAt",
+            "unique": false,
+            "columnNames": [
+              "recognizedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_recognizedAt` ON `${TABLE_NAME}` (`recognizedAt`)"
+          },
+          {
+            "name": "index_recognition_history_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_recognition_history_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`peerDeviceId` TEXT NOT NULL, `collection` TEXT NOT NULL, `payloadHash` TEXT NOT NULL, `appliedAt` INTEGER NOT NULL, `hwmHlc` TEXT NOT NULL, PRIMARY KEY(`peerDeviceId`, `collection`, `payloadHash`))",
+        "fields": [
+          {
+            "fieldPath": "peerDeviceId",
+            "columnName": "peerDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collection",
+            "columnName": "collection",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadHash",
+            "columnName": "payloadHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "appliedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hwmHlc",
+            "columnName": "hwmHlc",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "peerDeviceId",
+            "collection",
+            "payloadHash"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_peers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`deviceId` TEXT NOT NULL, `deviceName` TEXT NOT NULL, `platform` TEXT NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`deviceId`))",
+        "fields": [
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceName",
+            "columnName": "deviceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "deviceId"
+          ]
+        }
+      },
+      {
+        "tableName": "cached_translations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `engine` TEXT NOT NULL, `targetLanguage` TEXT NOT NULL, `sourceText` TEXT NOT NULL, `translatedText` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "engine",
+            "columnName": "engine",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetLanguage",
+            "columnName": "targetLanguage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceText",
+            "columnName": "sourceText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "translatedText",
+            "columnName": "translatedText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b1646c4f2c474e4fe8f63c26dcf01895')"
+    ]
+  }
+}

--- a/app/src/main/java/com/omersusin/pitube/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/omersusin/pitube/ui/screens/home/HomeViewModel.kt
@@ -254,7 +254,7 @@ private fun Video.withChannelMetadataFrom(enriched: Video): Video {
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val repository: YouTubeRepository,
-    private val subscriptionRepository: SubscriptionRepository, 
+    private val subscriptionRepository: SubscriptionRepository,
     private val shortsRepository: ShortsRepository,
     private val playerPreferences: com.omersusin.pitube.data.local.PlayerPreferences,
     @ApplicationContext private val appContext: Context
@@ -305,7 +305,7 @@ class HomeViewModel @Inject constructor(
     private val channelMetadataEnrichmentInFlight =
         java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
 
-    
+
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState
         .map(HomeUiState::withUniqueLazyContent)
@@ -314,7 +314,7 @@ class HomeViewModel @Inject constructor(
             started = SharingStarted.Eagerly,
             initialValue = _uiState.value.withUniqueLazyContent()
         )
-    
+
     private var currentPage: Page? = null
     private var isInitialized = false
     private val homePrefetchQueue = HomePrefetchQueue()
@@ -332,7 +332,7 @@ class HomeViewModel @Inject constructor(
             it.remove()
         }
     }
-    
+
     private var currentQueryIndex = 0
     private val discoveryQueries = mutableListOf<String>()
     private var wave2Job: Job? = null
@@ -440,14 +440,14 @@ class HomeViewModel @Inject constructor(
             }
         }
     }
-    
+
 
     fun initialize(context: Context) {
         if (isInitialized) return
         isInitialized = true
-        
+
         viewHistory = ViewHistory.getInstance(context)
-        
+
         viewModelScope.launch(PerformanceDispatcher.diskIO) {
             combine(
                 viewHistory!!.getVideoHistoryFlow(),
@@ -734,13 +734,13 @@ class HomeViewModel @Inject constructor(
             }
         }
     }
-    
+
 
     private fun updateVideosAndShorts(newVideos: List<Video>, append: Boolean = false) {
         val (newShorts, regularVideos) = newVideos.partition {
             it.isShort || (it.duration in 1..120 && !it.isLive)
         }
-        
+
         _uiState.update { state ->
             val watched = watchedVideoIds.value
             val unplayable = unplayableVideoIds.value
@@ -754,13 +754,13 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    
+
     fun loadFlowFeed(forceRefresh: Boolean = false) {
         if (_uiState.value.isLoading && !forceRefresh) return
-        
+
         wave2Job?.cancel()
         _uiState.update { it.copy(isLoading = true, error = null) }
-        
+
         viewModelScope.launch(PerformanceDispatcher.networkIO) {
             try {
                 // Rotate the ANONYMOUS visitor identity on a forced refresh so the
@@ -784,12 +784,11 @@ class HomeViewModel @Inject constructor(
 
                 val signedIn = !com.omersusin.pitube.innertube.YouTube.cookie.isNullOrBlank()
 
-                // ── Signed-in lane: the account's own "What to watch" feed ──
-                // Fetched in parallel with discovery below; blended into the mix
-                // instead of short-circuiting so the feed rotates through fresh
-                // items instead of repeating the same personalized set. The
-                // continuation token is preserved so scrolling can pull the
-                // next personalized page (feedContinuation drives load-more).
+                // ── Signed-in: show the account's actual "What to watch" feed ──
+                // This must not be mixed with locally generated discovery, trending,
+                // subscriptions, or history lanes. Those sources are useful only for
+                // anonymous browsing; YouTube already curates them for this account.
+                // This was the only issue lol kinda
                 val personalizedPool = if (signedIn) {
                     withTimeoutOrNull(12_000L) {
                         val primary = com.omersusin.pitube.innertube.YouTube.personalizedFeed()
@@ -801,41 +800,29 @@ class HomeViewModel @Inject constructor(
                                 result.videos
                             }
                             .orEmpty()
-                        // FEmusic_home / WEB_REMIX second lane (upstream Flow's
-                        // combination) when the www-WEB lane is bot-walled empty.
-                        val videos = if (primary.isNotEmpty()) primary else {
-                            Log.w(TAG, "Feed personal lane: FEwhat_to_watch empty — trying FEmusic_home fallback")
-                            com.omersusin.pitube.innertube.YouTube.musicHomeFeed()
-                                .getOrNull()
-                                ?.let { result ->
-                                    if (result.videos.isNotEmpty()) {
-                                        personalizedContinuation = result.continuation
-                                    }
-                                    result.videos
-                                }
-                                .orEmpty()
-                                .also { Log.w(TAG, "Feed personal lane: music-home fallback fetched=${it.size}") }
-                        }
-                        // KODA continuation-walk (HomeViewModel model): page 1 is
-                        // quasi-static; on a forced refresh keep walking pages
-                        // until ≥15 not-recently-shown items are collected.
-                        var walked = videos
+
+                        // The first page is commonly the same on consecutive loads.
+                        // Count *unseen* videos, not all page-one videos: otherwise a
+                        // 20-item stale page prevents refresh from ever following its
+                        // continuation to new recommendations.
+                        var walked = primary.distinctBy { it.id }
                         var walkCont = personalizedContinuation
                         if (forceRefresh) {
                             var pages = 0
-                            while (walked.size < 15 && walkCont != null && pages < 3) {
+                            fun unseenCount() = walked.count { it.id !in shownVideoIds }
+                            while (unseenCount() < 15 && walkCont != null && pages < 3) {
                                 val next = runCatching {
                                     com.omersusin.pitube.innertube.YouTube.personalizedFeedContinuation(walkCont).getOrNull()
                                 }.getOrNull() ?: break
                                 if (next.videos.isEmpty()) break
                                 walked = walked + next.videos.filter { candidate ->
-                                    candidate.id !in shownVideoIds && walked.none { it.id == candidate.id }
+                                    walked.none { it.id == candidate.id }
                                 }
                                 personalizedContinuation = next.continuation
                                 walkCont = next.continuation
                                 pages++
                             }
-                            Log.w(TAG, "Feed personal lane: continuation-walk total=${walked.size} (+${walked.size - videos.size}) across $pages extra pages")
+                            Log.w(TAG, "Feed personal lane: continuation-walk total=${walked.size}, unseen=${unseenCount()} across $pages extra pages")
                         }
                         walked
                             .filterSignedValid()
@@ -861,6 +848,52 @@ class HomeViewModel @Inject constructor(
                     }
                 } else {
                     emptyList()
+                }
+
+                if (signedIn) {
+                    // Keep YouTube's order. A refresh prefers unseen items but falls
+                    // back to the returned page if the account has no new items.
+                    val refreshed = if (forceRefresh && shownVideoIds.isNotEmpty()) {
+                        personalizedPool.filterNot { it.id in shownVideoIds }
+                            .ifEmpty { personalizedPool }
+                    } else {
+                        personalizedPool
+                    }
+                    val visible = refreshed
+                        .filterWatched(watchedVideoIds.value)
+                        .filterSuppressed(hiddenVideoIds.value, blockedChannelIds.value)
+                        .filterUnplayable(unplayableVideoIds.value)
+
+                    if (visible.isEmpty()) {
+                        Log.w(TAG, "Signed-in home feed returned no usable recommendations")
+                        _uiState.update { state ->
+                            state.copy(
+                                isLoading = false,
+                                isRefreshing = false,
+                                isFlowFeed = true,
+                                hasMorePages = personalizedContinuation != null,
+                                feedContinuation = personalizedContinuation,
+                                error = appContext.getString(R.string.error_failed_to_load_feed)
+                            )
+                        }
+                    } else {
+                        rememberShown(visible.map { it.id })
+                        _uiState.update { state ->
+                            state.copy(
+                                videos = visible,
+                                isLoading = false,
+                                isRefreshing = false,
+                                hasMorePages = personalizedContinuation != null,
+                                isFlowFeed = true,
+                                feedContinuation = personalizedContinuation,
+                                error = null,
+                                lastRefreshTime = System.currentTimeMillis()
+                            )
+                        }
+                        HomeFeedCache.update(visible, _uiState.value.shorts, signedIn = true)
+                        persistentHomeFeedCache.saveLastFeed(visible)
+                    }
+                    return@launch
                 }
 
                 // ── Taste-profile fallback (Koda getTasteBasedVideos pattern) ──
@@ -942,8 +975,8 @@ class HomeViewModel @Inject constructor(
 
                     val deferredDiscovery = async {
                         wave1Queries.map { query ->
-                            async { 
-                                runCatching { 
+                            async {
+                                runCatching {
                                     withTimeoutOrNull(6_000L) {
                                         repository.searchVideos(query).first
                                     }.orEmpty()
@@ -951,7 +984,7 @@ class HomeViewModel @Inject constructor(
                             }
                         }.awaitAll().flatten()
                     }
-                    
+
                     val deferredViral = async {
                         runCatching {
                              repository.getTrendingVideos(region).first
@@ -1031,7 +1064,7 @@ class HomeViewModel @Inject constructor(
                         state.copy(shorts = (state.shorts + feedShorts).distinctBy { it.id })
                     }
                 }
-                
+
                 // Filter to regular videos for the main feed
                 val watched = watchedVideoIds.value
                 val unplayable = unplayableVideoIds.value
@@ -1228,7 +1261,7 @@ HomeFeedCache.update(updated, state.shorts, signedIn = com.omersusin.pitube.inne
             }
         }
     }
-    
+
 
     private suspend fun loadNextPrefetchPage(generation: Int): Boolean {
         try {
@@ -1291,7 +1324,7 @@ HomeFeedCache.update(updated, state.shorts, signedIn = com.omersusin.pitube.inne
                         state.copy(shorts = (state.shorts + moreShorts).distinctBy { it.id })
                     }
                 }
-                
+
                 val newVideos = rawVideos.filterValid()
                     .filterWatched(watchedVideoIds.value).filterSuppressed(hiddenVideoIds.value, blockedChannelIds.value)
                     .filterUnplayable(unplayableVideoIds.value)
@@ -1418,7 +1451,7 @@ HomeFeedCache.update(updated, state.shorts, signedIn = com.omersusin.pitube.inne
             }
         }
     }
-    
+
 
     fun loadTrendingVideos() {
         if (_uiState.value.isLoading && _uiState.value.videos.isEmpty()) return
@@ -1465,7 +1498,7 @@ HomeFeedCache.update(updated, state.shorts, signedIn = com.omersusin.pitube.inne
             error = null
         )}
     }
-    
+
     fun refreshFeed() {
         resetHomePrefetch()
         wave2Job?.cancel()
@@ -1473,7 +1506,7 @@ HomeFeedCache.update(updated, state.shorts, signedIn = com.omersusin.pitube.inne
         _uiState.update { it.copy(isRefreshing = true) }
         loadFlowFeed(forceRefresh = true)
     }
-    
+
     fun retry() {
         resetHomePrefetch()
         wave2Job?.cancel()
@@ -1492,8 +1525,8 @@ HomeFeedCache.update(updated, state.shorts, signedIn = com.omersusin.pitube.inne
             .toList()
 
     private fun addUnique(
-        video: Video?, 
-        targetList: MutableList<Video>, 
+        video: Video?,
+        targetList: MutableList<Video>,
         channelCounts: MutableMap<String, Int>,
         usedVideoIds: MutableSet<String>,
         maxPerChannel: Int = 2
@@ -1529,11 +1562,11 @@ HomeFeedCache.update(updated, state.shorts, signedIn = com.omersusin.pitube.inne
 
         return false
     }
-    
+
     private fun List<Video>.filterValid(): List<Video> {
-        return this.filter { 
-            !it.isShort && 
-            ((it.duration > 120) || (it.duration == 0 && it.isLive)) 
+        return this.filter {
+            !it.isShort &&
+            ((it.duration > 120) || (it.duration == 0 && it.isLive))
         }
     }
 

--- a/app/src/main/java/com/omersusin/pitube/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/omersusin/pitube/ui/screens/home/HomeViewModel.kt
@@ -890,8 +890,14 @@ class HomeViewModel @Inject constructor(
                                 lastRefreshTime = System.currentTimeMillis()
                             )
                         }
-                        HomeFeedCache.update(visible, _uiState.value.shorts, signedIn = true)
-                        persistentHomeFeedCache.saveLastFeed(visible)
+                        try {
+                            HomeFeedCache.update(visible, _uiState.value.shorts, signedIn = true)
+                            persistentHomeFeedCache.saveLastFeed(visible)
+                        } catch (ce: CancellationException) {
+                            throw ce
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Signed-in feed cache write failed (feed still visible): ${e.message}")
+                        }
                     }
                     return@launch
                 }


### PR DESCRIPTION
Fix unseen count logic and cleanup whitespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signed-in users now receive a personalized “What to watch” feed tailored to their account.

* **Bug Fixes**
  * Improved feed refresh behavior by avoiding videos users have already seen.
  * Removed an unintended fallback that could replace an empty personalized feed with unrelated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->