### PR TITLE
fix: home feed parser + discovery music-leak + shorts storms + 403 re…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,9 +18,9 @@ android {
         applicationId = "com.omersusin.pitube"
         minSdk = 26
         targetSdk = 36
-        versionCode = 136
+        versionCode = 137
 
-        versionName = "3.9.7"
+        versionName = "3.9.8"
         testInstrumentationRunner = "com.omersusin.pitube.HiltTestRunner"
         vectorDrawables {
             useSupportLibrary = true

--- a/app/src/main/java/com/omersusin/pitube/FlowApplication.kt
+++ b/app/src/main/java/com/omersusin/pitube/FlowApplication.kt
@@ -266,7 +266,12 @@ class FlowApplication :
                 Log.w(TAG, "visitorData init error: ${e.message}")
             }
             launch {
-                kotlinx.coroutines.delay(10_000L)
+                // Deferred far past cold start: the prewarm spins up the
+                // BotGuard WebView (chromium). Loading it while the user is
+                // still settling on the home screen added to startup heating;
+                // an on-demand mint serves playback that starts earlier, and
+                // this then keeps the session warm for later.
+                kotlinx.coroutines.delay(45_000L)
                 try {
                     com.omersusin.pitube.utils.potoken.WebPoTokenSession
                         .prewarm()

--- a/app/src/main/java/com/omersusin/pitube/data/shorts/ShortsRepository.kt
+++ b/app/src/main/java/com/omersusin/pitube/data/shorts/ShortsRepository.kt
@@ -80,6 +80,23 @@ class ShortsRepository private constructor(private val context: Context) {
     private var cachedInitialFeed: ShortsSequenceResult? = null
     private var cachedFeedTimestamp = 0L
     private val CACHE_TTL_MS = 5 * 60 * 1000L // 5 minutes
+
+    // Single-flight: concurrent getShortsFeed(seed=null) callers share one
+    // in-flight fetch instead of each running the whole discovery pipeline
+    // (logcat showed 2 parallel pipelines at cold start and 7 after a
+    // profile switch — the main heating contributor).
+    private val initialFeedMutex = Mutex()
+    private var initialFeedInFlight: Deferred<ShortsSequenceResult>? = null
+
+    // Enrich-once bookkeeping: shorts whose metadata/avatar enrichment already
+    // completed are not re-enriched on later cache hits.
+    private val enrichedIds = mutableSetOf<String>()
+    private val avatarEnrichedChannels = mutableSetOf<String>()
+
+    // Stream URL lifetime guard: googlevideo URLs expire (~6h); a cached
+    // entry older than TTL is re-resolved instead of played into a 403.
+    private val streamResolvedAt = mutableMapOf<String, Long>()
+    private val STREAM_URL_TTL_MS = 4 * 60 * 60 * 1000L
     
     // Progressive enrichment events — UI observes this to update metadata live 
     private val _enrichmentUpdates = MutableSharedFlow<List<ShortVideo>>(extraBufferCapacity = 16)
@@ -100,6 +117,7 @@ class ShortsRepository private constructor(private val context: Context) {
         private const val ENRICHMENT_TIMEOUT_MS = 12_000L
         private const val MAX_RECENTLY_SHOWN = 100
         private const val MIN_POOL_SIZE = 10
+        private const val PRE_RESOLVE_LIMIT = 2
         
         @Volatile
         private var INSTANCE: ShortsRepository? = null
@@ -125,7 +143,7 @@ class ShortsRepository private constructor(private val context: Context) {
                 val filtered = cached.copy(shorts = filterWatchedShorts(cached.shorts))
                 if (filtered.shorts.isNotEmpty()) return@withContext filtered
             }
-            return@withContext fetchDiscoveryFeed()
+            return@withContext fetchDiscoveryFeedSingleFlight()
         }
 
         val rawResult = try {
@@ -145,6 +163,25 @@ class ShortsRepository private constructor(private val context: Context) {
 
         Log.w(TAG, "InnerTube seed failed — falling back to discovery feed")
         fetchDiscoveryFeed()
+    }
+
+    /**
+     * Single-flight wrapper around [fetchDiscoveryFeed]: the first caller
+     * runs the pipeline; everyone else awaits (and re-checks the cache once
+     * it lands) instead of racing duplicate discovery/enrichment work.
+     */
+    private suspend fun fetchDiscoveryFeedSingleFlight(): ShortsSequenceResult {
+        val existing = initialFeedMutex.withLock {
+            initialFeedInFlight ?: repositoryScope.async { fetchDiscoveryFeed() }
+                .also { initialFeedInFlight = it }
+        }
+        return try {
+            existing.await()
+        } finally {
+            initialFeedMutex.withLock {
+                if (initialFeedInFlight === existing) initialFeedInFlight = null
+            }
+        }
     }
 
     private suspend fun fetchDiscoveryFeed(): ShortsSequenceResult {
@@ -179,7 +216,11 @@ class ShortsRepository private constructor(private val context: Context) {
             markAsShown(itShorts.map { it.id })
             itShorts.forEach { shortsCache.put(it.id, it) }
 
-            repositoryScope.launch { preResolveStreams(itShorts.take(2).map { it.id }) }
+            // No speculative stream pre-resolve here: the shorts pager's own
+            // prefetch (ShortsViewModel.prefetchPlaybackStreams /
+            // preResolveStreams) resolves current+next on demand. Resolving
+            // here instead spun up the poToken WebView during cold start
+            // while the user was still on the home screen.
 
             val earlyResult = ShortsSequenceResult(itShorts, innerTubeResult.continuation)
             cachedInitialFeed = earlyResult
@@ -213,6 +254,13 @@ class ShortsRepository private constructor(private val context: Context) {
                         enriched.forEach { shortsCache.put(it.id, it) }
                         val withAvatars = enrichAvatarsForShorts(enriched)
                         withAvatars.forEach { shortsCache.put(it.id, it) }
+                        // Persist the ENRICHED feed so later cache hits don't
+                        // re-run player()/avatar enrichment for the same shorts.
+                        cachedInitialFeed = ShortsSequenceResult(
+                            withAvatars,
+                            innerTubeResult.continuation
+                        )
+                        cachedFeedTimestamp = System.currentTimeMillis()
                     }
                 } catch (e: Exception) {
                     Log.w(TAG, "Background enrichment failed: ${e.message}")
@@ -436,13 +484,13 @@ class ShortsRepository private constructor(private val context: Context) {
      * Results are cached to avoid re-resolution on swipe-back.
      */
     suspend fun resolveStreamInfo(videoId: String): StreamInfo? = withContext(Dispatchers.IO) {
-        streamInfoCache.get(videoId)?.let {
+        streamInfoCache.get(videoId)?.takeIf { isStreamCacheFresh(videoId) }?.let {
             Log.d(TAG, "♻ Stream cache hit: $videoId")
             return@withContext it
         }
-        
+
         Log.d(TAG, "⟳ Resolving stream: $videoId")
-        
+
         val streamInfo = try {
             withTimeoutOrNull(STREAM_RESOLVE_TIMEOUT_MS) {
                 youtubeRepository.getVideoStreamInfo(videoId)
@@ -451,14 +499,15 @@ class ShortsRepository private constructor(private val context: Context) {
             Log.w(TAG, "Stream resolution failed for $videoId: ${e.message}")
             null
         }
-        
+
         if (streamInfo != null) {
             streamInfoCache.put(videoId, streamInfo)
+            noteStreamResolved(videoId)
             Log.d(TAG, "✓ Resolved streams for $videoId")
         } else {
             Log.e(TAG, "✗ Failed to resolve streams for $videoId")
         }
-        
+
         streamInfo
     }
     
@@ -469,7 +518,7 @@ class ShortsRepository private constructor(private val context: Context) {
     ): ShortPlaybackStreams? = withContext(Dispatchers.IO) {
         val preferredCodecKey = PlayerPreferences(context).defaultVideoCodec.first().codecKey
         val cacheKey = "$videoId|$targetHeight|$preferredAudioLanguage|$preferredCodecKey"
-        playbackStreamsCache.get(cacheKey)?.let { return@withContext it }
+        playbackStreamsCache.get(cacheKey)?.takeIf { isStreamCacheFresh(cacheKey) }?.let { return@withContext it }
 
         val inFlight = streamResolveMutex.withLock {
             playbackStreamsInFlight[cacheKey]?.let { return@withLock it }
@@ -479,7 +528,10 @@ class ShortsRepository private constructor(private val context: Context) {
         }
 
         try {
-            inFlight.await()?.also { playbackStreamsCache.put(cacheKey, it) }
+            inFlight.await()?.also {
+                playbackStreamsCache.put(cacheKey, it)
+                noteStreamResolved(cacheKey)
+            }
         } finally {
             streamResolveMutex.withLock {
                 if (playbackStreamsInFlight[cacheKey] === inFlight) {
@@ -734,27 +786,57 @@ class ShortsRepository private constructor(private val context: Context) {
     }
 
     /**
-     * Pre-resolve streams for multiple video IDs concurrently.
-     * Used to pre-buffer adjacent shorts in the pager.
+     * Pre-resolve streams for multiple video IDs — only what the pager will
+     * actually touch next (current + 1), serialized, and skipping entries
+     * that are still fresh. The old all-parallel pre-resolve of whole pages
+     * was a large share of cold-start network/GC churn.
      */
     suspend fun preResolveStreams(videoIds: List<String>) = supervisorScope {
-        val uncached = videoIds.filter { streamInfoCache.get(it) == null }
+        val uncached = videoIds.take(PRE_RESOLVE_LIMIT).filter {
+            streamInfoCache.get(it) == null || !isStreamCacheFresh(it)
+        }
         if (uncached.isEmpty()) return@supervisorScope
-        
+
         Log.d(TAG, "⟳ Pre-resolving ${uncached.size} streams: ${uncached.joinToString()}")
-        
-        uncached.map { videoId ->
-            async(Dispatchers.IO) {
-                try {
-                    withTimeoutOrNull(STREAM_RESOLVE_TIMEOUT_MS) {
-                        resolveStreamInfo(videoId)
-                    }
-                } catch (e: Exception) {
-                    Log.w(TAG, "Pre-resolve failed for $videoId")
-                    null
+
+        for (videoId in uncached) {
+            try {
+                withTimeoutOrNull(STREAM_RESOLVE_TIMEOUT_MS) {
+                    resolveStreamInfo(videoId)
                 }
+            } catch (e: Exception) {
+                Log.w(TAG, "Pre-resolve failed for $videoId")
             }
-        }.forEach { it.await() } 
+        }
+    }
+
+    // ── Stream URL lifetime helpers ──────────────────────────────────────────
+    // googlevideo URLs expire (~6h). Cached entries older than the TTL must
+    // be re-resolved instead of played straight into a mid-stream 403.
+
+    private fun isStreamCacheFresh(key: String): Boolean {
+        val resolvedAt = streamResolvedAt[key] ?: return false
+        return System.currentTimeMillis() - resolvedAt < STREAM_URL_TTL_MS
+    }
+
+    private fun noteStreamResolved(key: String) {
+        streamResolvedAt[key] = System.currentTimeMillis()
+        if (streamResolvedAt.size > 200) {
+            val cutoff = System.currentTimeMillis() - STREAM_URL_TTL_MS
+            streamResolvedAt.entries.removeIf { it.value < cutoff }
+        }
+    }
+
+    /** Drop cached streams for [videoId] (e.g. after a 403) so the next resolve is fresh. */
+    fun evictStreamsFor(videoId: String) {
+        streamResolvedAt.remove(videoId)
+        streamInfoCache.remove(videoId)
+        val keys = playbackStreamsCache.snapshot().keys.filter { it.startsWith("$videoId|") }
+        keys.forEach {
+            playbackStreamsCache.remove(it)
+            streamResolvedAt.remove(it)
+        }
+        Log.d(TAG, "⟳ Evicted cached streams for $videoId (stale/403)")
     }
     
     // HOME FEED SHORTS — For the Home screen's Shorts shelf
@@ -793,18 +875,19 @@ class ShortsRepository private constructor(private val context: Context) {
         return ShortsSequenceResult(shorts, page.continuation)
     }
     
-    // INTERNAL — Metadata Enrichment    
+    // INTERNAL — Metadata Enrichment
     private suspend fun enrichMissingMetadata(shorts: List<ShortVideo>): List<ShortVideo> = supervisorScope {
-        val needsEnrichment = shorts.filter { 
-            it.title == "Short" || it.channelName == "Unknown" || it.channelName.isBlank() 
+        val needsEnrichment = shorts.filter {
+            (it.title == "Short" || it.channelName == "Unknown" || it.channelName.isBlank()) &&
+                it.id !in enrichedIds
         }
-        
+
         if (needsEnrichment.isEmpty()) return@supervisorScope shorts
-        
+
         Log.d(TAG, "⟳ Enriching metadata for ${needsEnrichment.size}/${shorts.size} shorts via player() endpoint")
-        
+
         val enrichedMap = mutableMapOf<String, ShortVideo>()
-        
+
         needsEnrichment.chunked(5).forEach { batch ->
             val batchResults = batch.map { short ->
                 async(Dispatchers.IO) {
@@ -850,13 +933,20 @@ class ShortsRepository private constructor(private val context: Context) {
                     }
                 }
             }.awaitAll()
-            
+
             batchResults.forEach { enrichedMap[it.id] = it }
-            
+
             val partiallyEnriched = shorts.map { enrichedMap[it.id] ?: it }
             _enrichmentUpdates.tryEmit(partiallyEnriched)
         }
-        
+
+        // A short with a real title AND channel is done: record it so cache
+        // hits never re-run the player()/next enrichment for it.
+        shorts.forEach { short ->
+            if (short.title != "Short" && short.channelName.isNotBlank() && short.channelName != "Unknown") {
+                enrichedIds.add(short.id)
+            }
+        }
         val result = shorts.map { enrichedMap[it.id] ?: it }
         Log.d(TAG, "✓ Enriched ${enrichedMap.size}/${needsEnrichment.size} shorts via player() endpoint")
         result
@@ -877,7 +967,7 @@ class ShortsRepository private constructor(private val context: Context) {
      */
     private suspend fun enrichAvatarsForShorts(shorts: List<ShortVideo>): List<ShortVideo> = supervisorScope {
         val channelIds = shorts
-            .filter { it.channelThumbnailUrl.isEmpty() && it.channelId.isNotEmpty() }
+            .filter { it.channelThumbnailUrl.isEmpty() && it.channelId.isNotEmpty() && it.channelId !in avatarEnrichedChannels }
             .map { it.channelId }
             .distinct()
 
@@ -889,7 +979,10 @@ class ShortsRepository private constructor(private val context: Context) {
             batch.map { id ->
                 async(Dispatchers.IO) { withTimeoutOrNull(6_000L) { id to youtubeRepository.fetchChannelAvatarById(id) } }
             }.awaitAll().forEach { pair ->
-                pair?.let { (id, url) -> if (url.isNotEmpty()) avatarMap[id] = url }
+                pair?.let { (id, url) ->
+                    avatarEnrichedChannels.add(id)
+                    if (url.isNotEmpty()) avatarMap[id] = url
+                }
             }
         }
 
@@ -961,6 +1054,9 @@ class ShortsRepository private constructor(private val context: Context) {
         streamInfoCache.evictAll()
         playbackStreamsCache.evictAll()
         shortsCache.evictAll()
+        streamResolvedAt.clear()
+        enrichedIds.clear()
+        avatarEnrichedChannels.clear()
         recentlyShownIds.clear()
         cachedInitialFeed = null
         cachedFeedTimestamp = 0L

--- a/app/src/main/java/com/omersusin/pitube/innertube/YouTube.kt
+++ b/app/src/main/java/com/omersusin/pitube/innertube/YouTube.kt
@@ -935,6 +935,22 @@ object YouTube {
         )
         val rawBody = httpResponse.bodyAsText()
         innerTube.noteResponseState(rawBody)
+        // Home feeds are shape-unstable: loose richItemRenderers alternate with
+        // richSectionRenderer shelves, payloads flip between videoRenderer and
+        // lockupViewModel, and a typed decode failure turns into a silent
+        // Result failure (parsed-empty with no diagnostics). Parse the body
+        // dynamically first — the typed channel parser stays as fallback.
+        val homeParsed = runCatching {
+            parseHomeFeedJson(rawBody, isContinuation = continuation != null)
+        }.getOrNull()
+        if (homeParsed != null && homeParsed.videos.isNotEmpty()) {
+            Log.w(
+                "YouTube",
+                "personalizedFeed($browseId): home parser ${homeParsed.videos.size} videos " +
+                    "(+${lastHomeShortsShelf.size} shorts shelf), cont=${homeParsed.continuation != null}",
+            )
+            return homeParsed
+        }
         val lenientJson = json
         val response = lenientJson.decodeFromString<ChannelVideosResponse>(rawBody)
         val parsed = parseChannelVideosResponse(response, "", "", "", false)
@@ -961,6 +977,13 @@ object YouTube {
                 val retryResponse = innerTube.signedWebBrowse(client = client, browseId = browseId, continuation = continuation, includeVisitor = false)
                 val retryBody = retryResponse.bodyAsText()
                 innerTube.noteResponseState(retryBody)
+                val retryHome = runCatching {
+                    parseHomeFeedJson(retryBody, isContinuation = continuation != null)
+                }.getOrNull()
+                if (retryHome != null && retryHome.videos.isNotEmpty()) {
+                    Log.w("YouTube", "personalizedFeed($browseId): retry (dynamic) recovered ${retryHome.videos.size} videos")
+                    return retryHome
+                }
                 val retryParsed = parseChannelVideosResponse(json.decodeFromString<ChannelVideosResponse>(retryBody), "", "", "", false)
                 if (retryParsed.videos.isNotEmpty()) Log.w("YouTube", "personalizedFeed($browseId): retry recovered ${retryParsed.videos.size} videos")
                 return retryParsed
@@ -969,6 +992,153 @@ object YouTube {
             Log.w("YouTube", "personalizedFeed($browseId): ${parsed.videos.size} videos, cont=${parsed.continuation != null}")
         }
         return parsed
+    }
+
+    // ── Home-feed ("What to watch") dynamic parser — Koda port ────────────────
+    //
+    // Mirrors Koda's verified (August 2026) home parsing: the signed WEB
+    // response is walked dynamically so unknown shapes can never break the
+    // whole feed, shelves are entered (richSectionRenderer), and both the
+    // classic videoRenderer and the modern lockupViewModel payload are read.
+    // Shorts shelf lockups are harvested separately — they feed the home
+    // shorts shelf and seed the personalized shorts sequence (sequenceParams),
+    // replacing the hardcoded "CA8%3D" cursor.
+
+    /** Shorts shelf harvested from the last successful home response. */
+    @Volatile
+    var lastHomeShortsShelf: List<com.omersusin.pitube.data.model.Video> = emptyList()
+        private set
+
+    /**
+     * sequenceParams seed from the last home shorts shelf. Refreshed whenever
+     * a signed home feed parses; the shorts feed consumes it so the initial
+     * reel sequence is the account's personalized one instead of a static
+     * default cursor.
+     */
+    @Volatile
+    var lastShortsSequenceSeed: String? = null
+        private set
+
+    private fun JsonElement?.homeObj(): JsonObject? = this as? JsonObject
+    private fun JsonElement?.homeArr(): JsonArray? = this as? JsonArray
+    private fun JsonElement?.homeStr(): String? =
+        (this as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
+
+    private fun parseHomeFeedJson(
+        body: String,
+        isContinuation: Boolean,
+    ): ChannelVideoSearchResult {
+        val root = runCatching { Json.parseToJsonElement(body) }.getOrNull()
+            ?: return ChannelVideoSearchResult(emptyList(), null, null)
+        val videos = mutableListOf<com.omersusin.pitube.data.model.Video>()
+        val shorts = mutableListOf<com.omersusin.pitube.data.model.Video>()
+        var nextContinuation: String? = null
+
+        fun walkItem(itemEl: JsonElement) {
+            val obj = itemEl.homeObj() ?: return
+            // 1. Loose grid item: richItemRenderer.content
+            obj["richItemRenderer"].homeObj()?.get("content").homeObj()?.let { content ->
+                parseHomeContent(content, videos, shorts)
+            }
+            // 2. Flat section item (e.g. date-grouped lists)
+            obj["itemSectionRenderer"].homeObj()?.get("contents").homeArr()?.forEach { sectionEl ->
+                sectionEl.homeObj()?.let { parseHomeContent(it, videos, shorts) }
+            }
+            // 3. Shelf ("Shorts", topic rows): walk the richItems inside
+            obj["richSectionRenderer"].homeObj()?.get("content").homeObj()?.let { shelf ->
+                val shelfItems = mutableListOf<JsonObject>()
+                findMusicObjectsByKey(shelf, "richItemRenderer", shelfItems)
+                shelfItems.forEach { richItem ->
+                    richItem["content"].homeObj()?.let { parseHomeContent(it, videos, shorts) }
+                }
+            }
+            // 4. Trailing continuation token
+            obj["continuationItemRenderer"].homeObj()
+                ?.get("continuationEndpoint").homeObj()
+                ?.get("continuationCommand").homeObj()
+                ?.get("token").homeStr()?.let { nextContinuation = it }
+        }
+
+        if (isContinuation) {
+            root.homeObj()?.get("onResponseReceivedActions").homeArr()?.forEach { action ->
+                action.homeObj()?.get("appendContinuationItemsAction").homeObj()
+                    ?.get("continuationItems").homeArr()?.forEach { itemEl -> walkItem(itemEl) }
+            }
+        } else {
+            val contents = root.homeObj()?.get("contents").homeObj()
+            val tabs = contents?.get("twoColumnBrowseResultsRenderer").homeObj()?.get("tabs").homeArr()
+                ?: contents?.get("singleColumnBrowseResultsRenderer").homeObj()?.get("tabs").homeArr()
+            val tabContent = tabs?.firstOrNull()?.homeObj()?.get("tabRenderer").homeObj()?.get("content").homeObj()
+            val gridContents = tabContent?.get("richGridRenderer").homeObj()?.get("contents").homeArr()
+                ?: tabContent?.get("sectionListRenderer").homeObj()?.get("contents").homeArr()
+            gridContents?.forEach { itemEl -> walkItem(itemEl) }
+        }
+
+        lastHomeShortsShelf = shorts
+        return ChannelVideoSearchResult(
+            videos = videos.distinctBy { it.id },
+            continuation = nextContinuation,
+        )
+    }
+
+    private fun parseHomeContent(
+        content: JsonObject,
+        videos: MutableList<com.omersusin.pitube.data.model.Video>,
+        shorts: MutableList<com.omersusin.pitube.data.model.Video>,
+    ) {
+        content["lockupViewModel"].homeObj()?.let { lockup ->
+            val typed = runCatching {
+                json.decodeFromJsonElement(ChannelVideosResponse.LockupViewModel.serializer(), lockup)
+            }.getOrNull()
+            typed?.let { parseLockupViewModel(it, "", "", "", false) }?.let(videos::add)
+        }
+        (content["videoRenderer"] ?: content["gridVideoRenderer"]).homeObj()?.let { vr ->
+            val typed = runCatching {
+                json.decodeFromJsonElement(ChannelVideosResponse.VideoRenderer.serializer(), vr)
+            }.getOrNull()
+            typed?.let { parseBrowseVideoRenderer(it, "", "", "", false) }?.let(videos::add)
+        }
+        content["shortsLockupViewModel"].homeObj()?.let { lockup ->
+            parseHomeShortsLockup(lockup)?.let(shorts::add)
+        }
+    }
+
+    /**
+     * shortsLockupViewModel: videoId + sequenceParams live in
+     * onTap.innertubeCommand.reelWatchEndpoint; title/views in
+     * overlayMetadata; portrait thumbnail in thumbnailViewModel.
+     */
+    private fun parseHomeShortsLockup(lockup: JsonObject): com.omersusin.pitube.data.model.Video? {
+        val reel = lockup["onTap"].homeObj()?.get("innertubeCommand").homeObj()?.get("reelWatchEndpoint").homeObj()
+            ?: return null
+        val videoId = reel["videoId"].homeStr()?.takeIf { it.length == 11 } ?: return null
+        val seed = reel["sequenceParams"].homeStr()
+        if (!seed.isNullOrBlank() && lastShortsSequenceSeed.isNullOrBlank()) {
+            lastShortsSequenceSeed = seed
+        }
+        val overlay = lockup["overlayMetadata"].homeObj()
+        val title = overlay?.get("primaryText").homeObj()?.get("content").homeStr().orEmpty()
+            .ifBlank { videoId }
+        val viewsText = overlay?.get("secondaryText").homeObj()?.get("content").homeStr().orEmpty()
+        val sources = lockup["thumbnailViewModel"].homeObj()?.get("image").homeObj()?.get("sources").homeArr()
+        val thumbnail = sources
+            ?.mapNotNull { it.homeObj()?.get("url").homeStr() }
+            ?.lastOrNull()
+            ?: reel["thumbnail"].homeObj()?.get("thumbnails").homeArr()
+                ?.firstOrNull()?.homeObj()?.get("url").homeStr()
+            ?: "https://i.ytimg.com/vi/$videoId/hq720.jpg"
+        return com.omersusin.pitube.data.model.Video(
+            id = videoId,
+            title = title,
+            channelName = "",
+            channelId = "",
+            thumbnailUrl = thumbnail,
+            duration = 0,
+            viewCount = parseViewCountText(viewsText),
+            uploadDate = "",
+            channelThumbnailUrl = "",
+            isShort = true,
+        )
     }
 
     // ============================================================
@@ -2871,9 +3041,12 @@ object YouTube {
         sequenceParams: String? = null,
         continuation: String? = null,
     ): Result<ShortsPage> = runCatching {
+        // Prefer the personalized seed harvested from the signed home feed's
+        // shorts shelf (Koda pattern) over the static default cursor: the
+        // hardcoded "CA8%3D" pins the same sequence for every session.
         innerTube.reel(
             client = YouTubeClient.ANDROID,
-            sequenceParams = sequenceParams ?: "CA8%3D",
+            sequenceParams = sequenceParams ?: lastShortsSequenceSeed ?: "CA8%3D",
             continuation = continuation
         ).toShortsPage()
     }

--- a/app/src/main/java/com/omersusin/pitube/player/shorts/ShortsPlayerPool.kt
+++ b/app/src/main/java/com/omersusin/pitube/player/shorts/ShortsPlayerPool.kt
@@ -21,13 +21,17 @@ import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.upstream.DefaultAllocator
 import com.omersusin.pitube.data.local.PlayerPreferences
 import com.omersusin.pitube.data.model.ShortVideo
+import com.omersusin.pitube.data.shorts.ShortsRepository
 import com.omersusin.pitube.player.analytics.PlaybackAnalyticsLogger
 import com.omersusin.pitube.player.config.PlayerConfig
 import com.omersusin.pitube.player.datasource.YouTubeHttpDataSource
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
@@ -61,6 +65,7 @@ class ShortsPlayerPool private constructor() {
         private const val BUFFER_FOR_PLAYBACK_MS = 250
         private const val BUFFER_FOR_REBUFFER_MS = 750
         private const val BACK_BUFFER_MS = 2_000
+        private const val MAX_STREAM_RECOVERIES = 2
 
         @Volatile
         private var instance: ShortsPlayerPool? = null
@@ -87,6 +92,17 @@ class ShortsPlayerPool private constructor() {
     private var preferredAudioLanguage: String = "original"
     private var shortsPlaybackMode: String = "loop"
     private var basePlaybackSpeed: Float = 1f
+    private var appContextRef: Context? = null
+
+    // ── 403/410 stream-expiry recovery ───────────────────────────────────────
+    // Shorts playback used to die on the first expired-URL 403 (logcat:
+    // "Playback error ... InvalidResponseCodeException: Response code: 403")
+    // because the pool had no error listener at all. Now the failed video's
+    // cached streams are evicted, re-resolved, and hot-swapped in place —
+    // the main player already does the same through PlayerErrorHandler.
+    private val recoveryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val recoveryAttempts = mutableMapOf<String, Int>()
+    private val recoveryInFlight = mutableSetOf<String>()
 
     private val preferenceObservers = ShortsPreferenceObservers()
 
@@ -111,6 +127,7 @@ class ShortsPlayerPool private constructor() {
         if (isInitialized) return
 
         val appContext = context.applicationContext
+        appContextRef = appContext
         Log.d(TAG, "Initializing 3-player pool for Shorts")
         dataSourceFactory = DefaultDataSource.Factory(appContext, YouTubeHttpDataSource.Factory())
         val preferences = PlayerPreferences(appContext)
@@ -133,7 +150,7 @@ class ShortsPlayerPool private constructor() {
 
         try {
             for (i in 0 until POOL_SIZE) {
-                players[i] = createShortsPlayer(appContext)
+                players[i] = createShortsPlayer(appContext, i)
                 playerOwnerIndices[i] = null
                 playerVideoIds[i] = null
             }
@@ -164,7 +181,7 @@ class ShortsPlayerPool private constructor() {
 
     // setViewportSizeToPhysicalDisplaySize has no non-deprecated API 35 replacement.
     @Suppress("DEPRECATION")
-    private fun createShortsPlayer(context: Context): ExoPlayer {
+    private fun createShortsPlayer(context: Context, slot: Int): ExoPlayer {
         val allocator = DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE)
         val (maxVideoWidth, maxVideoHeight) = maxVideoSizeForHeap(context)
 
@@ -221,7 +238,69 @@ class ShortsPlayerPool private constructor() {
                 playWhenReady = false
                 videoScalingMode = C.VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING
                 addAnalyticsListener(PlaybackAnalyticsLogger(TAG) { _currentVideoId.value })
+                addListener(object : Player.Listener {
+                    override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+                        handlePoolPlayerError(slot, error)
+                    }
+
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        // A slot that reached READY is playing fine — renew its
+                        // future recovery budget so an hours-later expiry can
+                        // still recover.
+                        if (playbackState == Player.STATE_READY) {
+                            playerVideoIds[slot]?.let { recoveryAttempts.remove(it) }
+                        }
+                    }
+                })
             }
+    }
+
+    /**
+     * Expired-URL (403/410) recovery for a pool player: evict the failed
+     * video's cached streams, re-resolve fresh URLs, and hot-swap them into
+     * the same slot at the same position. Max 2 recoveries per video, then
+     * the error surfaces (matching the main player's limiter behavior).
+     */
+    private fun handlePoolPlayerError(slot: Int, error: androidx.media3.common.PlaybackException) {
+        val causeText = error.cause?.message.orEmpty()
+        val isExpiredUrl = error.errorCode == androidx.media3.common.PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS &&
+            (causeText.contains("Response code: 403") || causeText.contains("Response code: 410")) ||
+            ((error.errorCode == androidx.media3.common.PlaybackException.ERROR_CODE_IO_UNSPECIFIED ||
+                error.errorCode == androidx.media3.common.PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED) &&
+                (causeText.contains("Response code: 403") || causeText.contains("Response code: 410")))
+        if (!isExpiredUrl) return
+
+        val videoId = playerVideoIds[slot] ?: return
+        val index = playerOwnerIndices[slot] ?: return
+        val attempts = (recoveryAttempts[videoId] ?: 0) + 1
+        recoveryAttempts[videoId] = attempts
+        if (attempts > MAX_STREAM_RECOVERIES || videoId in recoveryInFlight) {
+            Log.w(TAG, "Stream recovery for $videoId skipped (attempt $attempts, inFlight=${videoId in recoveryInFlight})")
+            return
+        }
+
+        Log.w(TAG, "Stream 403/410 for short $videoId — evicting cache and re-resolving (attempt $attempts/$MAX_STREAM_RECOVERIES)")
+        val context = appContextRef ?: return
+        recoveryInFlight.add(videoId)
+        recoveryScope.launch {
+            try {
+                val repository = ShortsRepository.getInstance(context)
+                repository.evictStreamsFor(videoId)
+                val fresh = repository.resolvePlaybackStreams(videoId, 0, preferredAudioLanguage)
+                if (fresh != null) {
+                    withContext(Dispatchers.Main) {
+                        reloadWithUrls(index, videoId, fresh.videoUrl, fresh.audioUrl)
+                        Log.w(TAG, "Stream recovery for $videoId succeeded — hot-swapped fresh URLs")
+                    }
+                } else {
+                    Log.e(TAG, "Stream recovery for $videoId failed to resolve fresh URLs")
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Stream recovery for $videoId crashed: ${e.message}")
+            } finally {
+                recoveryInFlight.remove(videoId)
+            }
+        }
     }
 
     private fun maxVideoSizeForHeap(context: Context): Pair<Int, Int> {
@@ -415,6 +494,31 @@ class ShortsPlayerPool private constructor() {
         player.setPlaybackSpeed(basePlaybackSpeed)
         player.playWhenReady = wasPlaying
         player.seekTo(position)
+        player.repeatMode = if (shortsPlaybackMode == "loop") Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
+    }
+
+    /**
+     * Hot-swap BOTH video and audio URLs for an already-prepared player slot
+     * (stream-expiry recovery). Keeps position and playback state.
+     */
+    fun reloadWithUrls(index: Int, videoId: String, newVideoUrl: String, newAudioUrl: String?) {
+        if (!isInitialized || index < 0) return
+        val slot = index % POOL_SIZE
+        val player = players[slot] ?: return
+        if (playerOwnerIndices[slot] != index) return
+
+        val wasPlaying = player.isPlaying || player.playWhenReady
+        val position = player.currentPosition
+
+        player.stop()
+        player.clearMediaItems()
+        playerVideoUrls[slot] = newVideoUrl
+        playerAudioUrls[slot] = newAudioUrl
+
+        preparePlayerInternal(player, newVideoUrl, newAudioUrl)
+        player.setPlaybackSpeed(basePlaybackSpeed)
+        player.playWhenReady = wasPlaying
+        if (position > 0) player.seekTo(position)
         player.repeatMode = if (shortsPlaybackMode == "loop") Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
     }
 

--- a/app/src/main/java/com/omersusin/pitube/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/omersusin/pitube/ui/screens/home/HomeViewModel.kt
@@ -998,7 +998,13 @@ class HomeViewModel @Inject constructor(
 
                 val now = System.currentTimeMillis()
 
-                val feedShorts = (rawSubs.extractShorts() + rawDiscovery.extractShorts() + rawViral.extractShorts())
+                // The signed home response's own Shorts shelf (harvested by the
+                // home parser) joins the shorts lane so the shelf reflects the
+                // account's personalized shorts, not just subs/discovery spill.
+                val homeShelfShorts = if (signedIn) {
+                    com.omersusin.pitube.innertube.YouTube.lastHomeShortsShelf
+                } else emptyList()
+                val feedShorts = (homeShelfShorts + rawSubs.extractShorts() + rawDiscovery.extractShorts() + rawViral.extractShorts())
                     .distinctBy { it.id }
                     .filterWatched(watchedVideoIds.value).filterSuppressed(hiddenVideoIds.value, blockedChannelIds.value)
                     .filterUnplayable(unplayableVideoIds.value)

--- a/app/src/main/java/com/omersusin/pitube/ui/screens/search/DiscoverViewModel.kt
+++ b/app/src/main/java/com/omersusin/pitube/ui/screens/search/DiscoverViewModel.kt
@@ -189,16 +189,7 @@ class DiscoverViewModel
                 withContext(kotlinx.coroutines.Dispatchers.IO) {
                     com.omersusin.pitube.innertube.YouTube.personalizedFeed().getOrNull()
                 }
-            val firstLane =
-                primary?.videos?.also { continuation = primary.continuation }.orEmpty()
-            if (firstLane.isNotEmpty()) return firstLane
-
-            // FEmusic_home / WEB_REMIX second lane when www-WEB is bot-walled empty.
-            val fallback =
-                withContext(kotlinx.coroutines.Dispatchers.IO) {
-                    com.omersusin.pitube.innertube.YouTube.musicHomeFeed().getOrNull()
-                }
-            return fallback?.videos.orEmpty().also { continuation = fallback?.continuation }
+            return primary?.videos.also { continuation = primary?.continuation }.orEmpty()
         }
 
         /**


### PR DESCRIPTION
…covery + startup heating (3.9.8/137)

- Home feed: Koda-ported dynamic FEwhat_to_watch parser (richGrid/richSection shelves, lockupViewModel + videoRenderer + gridVideoRenderer, continuation); PERSONAL lane was parsed-empty because the channel parser can't read the home shape while the session itself was fine (FEsubscriptions worked).
- Discover: removed FEmusic_home/WEB_REMIX fallback that flooded the Discover surface with YouTube Music content ("discovery thinks it's YT Music").
- Home shorts shelf now seeded from the signed home response's own Shorts shelf; the reel sequence prefers the shelf's sequenceParams over the hardcoded CA8%3D cursor (same content every session).
- ShortsRepository: single-flight initial feed (2 parallel fetches at cold start, 7 after profile switch), enriched feed persisted to cache + enrich-once bookkeeping (player()/avatar enrichment no longer re-runs per cache hit), stream URL TTL (~4h) so expired googlevideo URLs re-resolve instead of 403-ing, pre-resolve capped+serialized.
- ShortsPlayerPool: onPlayerError 403/410 recovery — evict cached streams, re-resolve, hot-swap URLs in place at current position (max 2/video, renewed on READY); shorts playback no longer dies on first expired URL.
- Startup heating: poToken WebView prewarm deferred 10s→45s past cold start; speculative shorts stream pre-resolve (which spun up chromium on the home screen) removed in favor of the pager's own on-demand prefetch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personalized Shorts are now prioritized in the Home feed for signed-in viewers.
  * Shorts playback can automatically recover from expired stream links while preserving playback position.
  * Home feeds can use dynamically discovered Shorts content and continuation data.

* **Bug Fixes**
  * Improved Shorts feed loading, caching, and metadata enrichment for more reliable results.
  * Removed the unrelated music-feed fallback when personalized Discover results are empty.

* **Chores**
  * Updated the app version to 3.9.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->